### PR TITLE
replication: set status.State to secondary when VR is marked as

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -217,7 +217,9 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			replicationErr = r.markVolumeAsSecondary(instance, logger, volumeHandle, parameters, secret)
 			if replicationErr == nil {
 				logger.Info("volume is not ready to use")
-				err = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), "volume is degraded")
+				// set the status.State to secondary as the
+				// instance.Status.State is primary for the first time.
+				err = r.updateReplicationStatus(instance, logger, getReplicationState(instance), "volume is marked secondary and is degraded")
 				if err != nil {
 					return ctrl.Result{}, err
 				}


### PR DESCRIPTION
secondary

when the VR is marked as secondary the current
instance object still contains the status.State
as primary not secondary. we need to set the
status.State to secondary when the volume
is demoted successfully.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>